### PR TITLE
Fix "C18 draft" link

### DIFF
--- a/_posts/2023-02-11-My-review-of-the-C-standard-library.markdown
+++ b/_posts/2023-02-11-My-review-of-the-C-standard-library.markdown
@@ -37,7 +37,7 @@ advantage of that fact, bypassing the original issue entirely by calling
 directly into the platform.
 
 The rest of this article is goes through the standard library listing in
-[the C18 draft][draft] mostly in order.
+[the C18 draft][drafts] mostly in order.
 
 ### assert and abort
 


### PR DESCRIPTION
I have assumed you meant to use the list of drafts in the SO post since the link was defined here.